### PR TITLE
fix: exclude integration tests from unit test run

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -19,6 +19,11 @@ const config: Config = {
     '**/__tests__/**/*.[jt]s?(x)',
     '**/?(*.)+(spec|test).[jt]s?(x)',
   ],
+  testPathIgnorePatterns: [
+    '<rootDir>/node_modules/',
+    '<rootDir>/.next/',
+    '<rootDir>/tests/integration/',
+  ],
   collectCoverageFrom: [
     'src/**/*.{js,jsx,ts,tsx}',
     '!src/**/*.d.ts',


### PR DESCRIPTION
The jest.config.ts testMatch pattern was also matching tests/integration/smoke.test.ts. The smoke tests require a running server at http://localhost:3000, causing them to fail when run as part of the unit test suite.

Added testPathIgnorePatterns to exclude the tests/integration/ directory from the unit test configuration.

Closes #11

Generated with [Claude Code](https://claude.ai/code)