### PR TITLE
Fix studio gateway timeout

### DIFF
--- a/studio/Dockerfile
+++ b/studio/Dockerfile
@@ -44,7 +44,7 @@ EXPOSE 3333
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-  CMD wget --quiet --tries=1 --spider http://localhost:3333/ || exit 1
+  CMD wget --quiet --tries=1 --spider http://127.0.0.1:3333/ || exit 1
 
 # Serve static files with proper SPA routing
-CMD ["serve", "dist", "-l", "3333", "--no-clipboard", "--single"]
+CMD ["serve", "dist", "-l", "tcp:0.0.0.0:3333", "--no-clipboard", "--single"]


### PR DESCRIPTION
## Summary
- Bind Sanity Studio's `serve` to `tcp:0.0.0.0:3333` so Coolify's reverse proxy can reach it via IPv4 on the Docker bridge network
- Update Dockerfile healthcheck to use `127.0.0.1` instead of `localhost` to avoid IPv6/IPv4 ambiguity

## Root cause
`serve` with `-l 3333` was binding to IPv6 only in the container. Coolify's Traefik proxy routes traffic via IPv4 on the Docker bridge network, so it couldn't reach the service — resulting in a 502/504 gateway error despite health checks (hitting `::1`) succeeding.

## Test plan
- [ ] Deploy to Coolify and verify studio.casperdamen.eu loads without gateway timeout