### PR TITLE
feat: add client logos section

### DIFF
--- a/sanity-schemas/clients.ts
+++ b/sanity-schemas/clients.ts
@@ -1,0 +1,53 @@
+import { defineType, defineField } from 'sanity'
+
+export default defineType({
+  name: 'clients',
+  title: 'Client Logos',
+  type: 'document',
+  fields: [
+    defineField({
+      name: 'clients',
+      title: 'Clients',
+      type: 'array',
+      of: [
+        {
+          type: 'object',
+          name: 'client',
+          title: 'Client',
+          fields: [
+            {
+              name: 'name',
+              title: 'Client Name',
+              type: 'string',
+              validation: (Rule) => Rule.required(),
+            },
+            {
+              name: 'logo',
+              title: 'Logo',
+              type: 'image',
+              options: { hotspot: true },
+              fields: [
+                {
+                  name: 'alt',
+                  title: 'Alt Text',
+                  type: 'string',
+                  description: 'Describe the logo for accessibility (defaults to client name)',
+                },
+              ],
+              validation: (Rule) => Rule.required(),
+            },
+            {
+              name: 'url',
+              title: 'Website URL',
+              type: 'url',
+              description: 'Optional link to the client website',
+            },
+          ],
+          preview: {
+            select: { title: 'name', media: 'logo' },
+          },
+        },
+      ],
+    }),
+  ],
+})

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,11 +4,13 @@ import About from '@/components/About'
 import FeaturedProjects from '@/components/FeaturedProjects'
 import RecentBlogPosts from '@/components/RecentBlogPosts'
 import Skills from '@/components/Skills'
+import ClientLogos from '@/components/ClientLogos'
 import {
   getHomepageContent,
   getFeaturedProjects,
   getRecentBlogPosts,
   getSkills,
+  getClientLogos,
 } from '@/lib/cms'
 
 export const revalidate = 3600
@@ -40,11 +42,12 @@ export async function generateMetadata(): Promise<Metadata> {
 }
 
 export default async function HomePage() {
-  const [homepage, featuredProjects, recentPosts, skills] = await Promise.all([
+  const [homepage, featuredProjects, recentPosts, skills, clientLogos] = await Promise.all([
     getHomepageContent(),
     getFeaturedProjects(3),
     getRecentBlogPosts(3),
     getSkills(),
+    getClientLogos(),
   ])
 
   return (
@@ -62,6 +65,7 @@ export default async function HomePage() {
       <div id="blog">
         <RecentBlogPosts posts={recentPosts} />
       </div>
+      <ClientLogos clientLogos={clientLogos} />
     </main>
   )
 }

--- a/src/components/ClientLogos.tsx
+++ b/src/components/ClientLogos.tsx
@@ -1,0 +1,55 @@
+import Image from 'next/image'
+import type { ClientLogos } from '@/types/cms'
+
+interface ClientLogosProps {
+  clientLogos: ClientLogos
+}
+
+export default function ClientLogos({ clientLogos }: ClientLogosProps) {
+  if (clientLogos.clients.length === 0) {
+    return null
+  }
+
+  return (
+    <section id="clients" className="py-16 px-4 sm:px-6 lg:px-8">
+      <div className="max-w-7xl mx-auto">
+        <h2 className="text-4xl font-bold mb-12 text-center">Clients</h2>
+        <div className="flex flex-wrap justify-center items-center gap-8 sm:gap-12">
+          {clientLogos.clients.map((client) => {
+            const logo = (
+              <div className="relative w-32 h-16 grayscale hover:grayscale-0 opacity-70 hover:opacity-100 transition-all duration-300">
+                <Image
+                  src={client.logo.url}
+                  alt={client.logo.alt || client.name}
+                  fill
+                  className="object-contain"
+                />
+              </div>
+            )
+
+            if (client.url) {
+              return (
+                <a
+                  key={client.name}
+                  href={client.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  aria-label={`Visit ${client.name}`}
+                  className="focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 rounded"
+                >
+                  {logo}
+                </a>
+              )
+            }
+
+            return (
+              <div key={client.name} aria-label={client.name}>
+                {logo}
+              </div>
+            )
+          })}
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/src/lib/cms.ts
+++ b/src/lib/cms.ts
@@ -6,8 +6,8 @@
  * to ensure backward compatibility with existing page components.
  */
 
-import type { Homepage, Project, BlogPost, Skills } from '@/types/cms'
-import type { SanityHomepage, SanityPost, SanityProject, SanitySkills } from '@/types/cms'
+import type { Homepage, Project, BlogPost, Skills, ClientLogos } from '@/types/cms'
+import type { SanityHomepage, SanityPost, SanityProject, SanitySkills, SanityClients } from '@/types/cms'
 import { getClient } from './sanity/client'
 import {
   homepageQuery,
@@ -20,8 +20,9 @@ import {
   allProjectSlugsQuery,
   featuredProjectsQuery,
   skillsQuery,
+  clientLogosQuery,
 } from './sanity/queries'
-import { mapHomepage, mapPost, mapProject, mapPosts, mapProjects, mapSkills } from './sanity/mappers'
+import { mapHomepage, mapPost, mapProject, mapPosts, mapProjects, mapSkills, mapClientLogos } from './sanity/mappers'
 
 /**
  * Fetch homepage content from Sanity
@@ -200,6 +201,22 @@ export async function getSkills(preview = false): Promise<Skills> {
   } catch (error) {
     console.error('Error fetching skills content:', error)
     return { techCategories: [], certifications: [] }
+  }
+}
+
+/**
+ * Fetch client logos content from Sanity
+ * @param preview - Enable draft/preview mode
+ * @returns ClientLogos content (empty clients array if not yet created)
+ */
+export async function getClientLogos(preview = false): Promise<ClientLogos> {
+  try {
+    const client = getClient(preview)
+    const data = await client.fetch<SanityClients | null>(clientLogosQuery)
+    return mapClientLogos(data)
+  } catch (error) {
+    console.error('Error fetching client logos:', error)
+    return { clients: [] }
   }
 }
 

--- a/src/lib/sanity/mappers.ts
+++ b/src/lib/sanity/mappers.ts
@@ -8,10 +8,12 @@ import type {
   SanityPost,
   SanityProject,
   SanitySkills,
+  SanityClients,
   Homepage,
   BlogPost,
   Project,
   Skills,
+  ClientLogos,
   SanityImage,
   ProcessedImage,
 } from '@/types/cms'
@@ -122,6 +124,31 @@ export function mapPosts(docs: SanityPost[]): BlogPost[] {
  */
 export function mapProjects(docs: SanityProject[]): Project[] {
   return docs.map(mapProject)
+}
+
+/**
+ * Map Sanity clients document to ClientLogos interface
+ * @param doc - Raw Sanity clients document (may be null if not yet created)
+ * @returns ClientLogos object for application use
+ */
+export function mapClientLogos(doc: SanityClients | null): ClientLogos {
+  if (!doc) {
+    return { clients: [] }
+  }
+
+  return {
+    clients: (doc.clients || [])
+      .map((client) => {
+        const logo = mapSanityImage(client.logo, client.name)
+        if (!logo) return null
+        return {
+          name: client.name,
+          logo,
+          url: client.url,
+        }
+      })
+      .filter((c): c is NonNullable<typeof c> => c !== null),
+  }
 }
 
 /**

--- a/src/lib/sanity/queries.ts
+++ b/src/lib/sanity/queries.ts
@@ -227,6 +227,26 @@ export const skillsQuery = `
 `
 
 /**
+ * Client Logos Queries
+ */
+
+// Fetch the clients singleton document
+export const clientLogosQuery = `
+  *[_type == "clients"][0] {
+    _id,
+    _type,
+    "clients": clients[] {
+      _key,
+      name,
+      "logo": logo {
+        ${imageProjection}
+      },
+      url
+    }
+  }
+`
+
+/**
  * Type guard to check if a query result is non-null
  * @param result - Query result to check
  * @returns True if result exists

--- a/src/types/cms.ts
+++ b/src/types/cms.ts
@@ -1,6 +1,37 @@
 import type { Image } from 'sanity'
 
 /**
+ * A single client with logo
+ */
+export interface Client {
+  name: string
+  logo: ProcessedImage
+  url?: string
+}
+
+/**
+ * Client logos section content
+ * Singleton document
+ */
+export interface ClientLogos {
+  clients: Client[]
+}
+
+/**
+ * Raw clients document from Sanity
+ */
+export interface SanityClients {
+  _id: string
+  _type: 'clients'
+  clients?: Array<{
+    _key: string
+    name: string
+    logo: SanityImage
+    url?: string
+  }>
+}
+
+/**
  * A single technology item (language, tool, platform, etc.)
  */
 export interface TechItem {

--- a/studio/sanity.config.ts
+++ b/studio/sanity.config.ts
@@ -7,12 +7,13 @@ import homepage from '../sanity-schemas/homepage'
 import post from '../sanity-schemas/post'
 import project from '../sanity-schemas/project'
 import skills from '../sanity-schemas/skills'
+import clients from '../sanity-schemas/clients'
 
 // Define the actions that should be available for singleton documents
 const singletonActions = new Set(['publish', 'discardChanges', 'restore'])
 
 // Define the singleton document types
-const singletonTypes = new Set(['homepage', 'skills'])
+const singletonTypes = new Set(['homepage', 'skills', 'clients'])
 
 export default defineConfig({
   name: 'default',
@@ -45,6 +46,15 @@ export default defineConfig({
                   .schemaType('skills')
                   .documentId('skills')
               ),
+            // Singleton clients document
+            S.listItem()
+              .title('Client Logos')
+              .id('clients')
+              .child(
+                S.document()
+                  .schemaType('clients')
+                  .documentId('clients')
+              ),
             // Divider
             S.divider(),
             // Regular document types
@@ -56,7 +66,7 @@ export default defineConfig({
   ],
 
   schema: {
-    types: [homepage, post, project, skills],
+    types: [homepage, post, project, skills, clients],
     // Filter out singleton types from the global "New document" menu
     templates: (templates) =>
       templates.filter(({ schemaType }) => !singletonTypes.has(schemaType)),


### PR DESCRIPTION
Add a Client Logos section to the homepage with full Sanity Studio support for uploading images.

Closes #22

Generated with [Claude Code](https://claude.ai/code)